### PR TITLE
Full CD emulation support for DriveDroid

### DIFF
--- a/drivers/usb/gadget/f_mass_storage.c
+++ b/drivers/usb/gadget/f_mass_storage.c
@@ -1074,7 +1074,11 @@ static int do_read(struct fsg_common *common)
 		curlun->sense_data = SS_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
 		return -EINVAL;
 	}
-	file_offset = ((loff_t) lba) << 9;
+  if (curlun->cdrom)
+    file_offset = ((loff_t) lba) << 11;
+  else
+    file_offset = ((loff_t) lba) << 9;
+
 
 	/* Carry out the file reads */
 	amount_left = common->data_size_from_cmnd;
@@ -1089,6 +1093,8 @@ static int do_read(struct fsg_common *common)
 		bh->inreq->length = 0;
 		return -EIO;		/* No default reply */
 	}
+  if (curlun->cdrom)
+    amount_left <<= 2;
 
 	for (;;) {
 		/*
@@ -1663,7 +1669,7 @@ static int do_read_capacity(struct fsg_common *common, struct fsg_buffhd *bh)
 
 	put_unaligned_be32(curlun->num_sectors - 1, &buf[0]);
 						/* Max logical block */
-	put_unaligned_be32(512, &buf[4]);	/* Block length */
+	put_unaligned_be32(curlun->cdrom ? 2048 : 512, &buf[4]);	/* Block length */
 	return 8;
 }
 
@@ -1922,7 +1928,7 @@ static int do_read_format_capacities(struct fsg_common *common,
 
 	put_unaligned_be32(curlun->num_sectors, &buf[0]);
 						/* Number of blocks */
-	put_unaligned_be32(512, &buf[4]);	/* Block length */
+	put_unaligned_be32(curlun->cdrom ? 2048 : 512, &buf[4]);	/* Block length */
 	buf[4] = 0x02;				/* Current capacity */
 	return 12;
 }
@@ -2472,16 +2478,7 @@ static int do_scsi_command(struct fsg_common *common)
 		common->data_size_from_cmnd =
 			get_unaligned_be16(&common->cmnd[7]);
 		reply = check_command(common, 10, DATA_DIR_TO_HOST,
-#if defined(CONFIG_USB_CDFS_SUPPORT)
-#ifdef _SUPPORT_MAC_
 				      (0xf<<6) | (1<<1), 1,
-#else
-				      (7<<6) | (1<<1), 1,
-#endif
-#else
-				      (7<<6) | (1<<1), 1,
-#endif
-
 				      "READ TOC");
 		if (reply == 0)
 			reply = do_read_toc(common, bh);
@@ -3145,6 +3142,7 @@ static int fsg_main_thread(void *common_)
 static DEVICE_ATTR(ro, 0644, fsg_show_ro, fsg_store_ro);
 static DEVICE_ATTR(nofua, 0644, fsg_show_nofua, fsg_store_nofua);
 static DEVICE_ATTR(file, 0644, fsg_show_file, fsg_store_file);
+static DEVICE_ATTR(cdrom, 0644, fsg_show_cdrom, fsg_store_cdrom);
 
 
 /****************************** FSG COMMON ******************************/
@@ -3272,6 +3270,10 @@ static struct fsg_common *fsg_common_init(struct fsg_common *common,
 		rc = device_create_file(&curlun->dev, &dev_attr_nofua);
 		if (rc)
 			goto error_luns;
+    rc = device_create_file(&curlun->dev, &dev_attr_cdrom);
+    if (rc)
+      goto error_luns;
+
 
 		if (lcfg->filename) {
 			rc = fsg_lun_open(curlun, lcfg->filename);
@@ -3413,6 +3415,7 @@ static void fsg_common_release(struct kref *ref)
 			device_remove_file(&lun->dev, &dev_attr_nofua);
 			device_remove_file(&lun->dev, &dev_attr_ro);
 			device_remove_file(&lun->dev, &dev_attr_file);
+			device_remove_file(&lun->dev, &dev_attr_cdrom);
 			fsg_lun_close(lun);
 			device_unregister(&lun->dev);
 		}

--- a/drivers/usb/gadget/storage_common.c
+++ b/drivers/usb/gadget/storage_common.c
@@ -729,10 +729,10 @@ static int fsg_lun_open(struct fsg_lun *curlun, const char *filename)
 	num_sectors = size >> 9;	/* File size in 512-byte blocks */
 	min_sectors = 1;
 	if (curlun->cdrom) {
-		num_sectors &= ~3;	/* Reduce to a multiple of 2048 */
-		min_sectors = 300*4;	/* Smallest track is 300 frames */
-		if (num_sectors >= 256*60*75*4) {
-			num_sectors = (256*60*75 - 1) * 4;
+		num_sectors >>= 2;  /* Reduce to a multiple of 2048 */
+		min_sectors = 300;  /* Smallest track is 300 frames */
+		if (num_sectors >= 256*60*75) {
+			num_sectors = (256*60*75 - 1);
 			LINFO(curlun, "file too big: %s\n", filename);
 			LINFO(curlun, "using only first %d blocks\n",
 					(int) num_sectors);
@@ -787,7 +787,6 @@ static void store_cdrom_address(u8 *dest, int msf, u32 addr)
 {
 	if (msf) {
 		/* Convert to Minutes-Seconds-Frames */
-		addr >>= 2;		/* Convert to 2048-byte frames */
 		addr += 2*75;		/* Lead-in occupies 2 seconds */
 		dest[3] = addr % 75;	/* Frames */
 		addr /= 75;
@@ -940,4 +939,41 @@ static ssize_t fsg_store_file(struct device *dev, struct device_attribute *attr,
 	}
 	up_write(filesem);
 	return (rc < 0 ? rc : count);
+}
+
+static ssize_t fsg_show_cdrom (struct device *dev, struct device_attribute *attr,
+         char *buf)
+{
+  struct fsg_lun  *curlun = fsg_lun_from_dev(dev);
+
+  return sprintf(buf, "%d\n", curlun->cdrom);
+}
+
+static ssize_t fsg_store_cdrom(struct device *dev, struct device_attribute *attr,
+          const char *buf, size_t count)
+{
+  ssize_t    rc;
+  struct fsg_lun  *curlun = fsg_lun_from_dev(dev);
+  struct rw_semaphore  *filesem = dev_get_drvdata(dev);
+  unsigned  cdrom;
+
+  rc = kstrtouint(buf, 2, &cdrom);
+  if (rc)
+    return rc;
+
+  /*
+   * Allow the cdrom status to change only while the
+   * backing file is closed.
+   */
+  down_read(filesem);
+  if (fsg_lun_is_open(curlun)) {
+    LDBG(curlun, "cdrom status change prevented\n");
+    rc = -EBUSY;
+  } else {
+    curlun->cdrom = cdrom;
+    LDBG(curlun, "cdrom status set to %d\n", curlun->cdrom);
+    rc = count;
+  }
+  up_read(filesem);
+  return rc;
 }


### PR DESCRIPTION
I just applied the two patches mentioned in the DriveDroid thread http://forum.xda-developers.com/showthread.php?t=2196707

You need to disable USB auto-mounting in STweaks for it to work.
