### PR TITLE
Fix the infamous Music/sdcard/FPU corruption bug.

### DIFF
--- a/arch/arm/mach-exynos/cpuidle-exynos4.c
+++ b/arch/arm/mach-exynos/cpuidle-exynos4.c
@@ -10,6 +10,7 @@
 
 #include <linux/kernel.h>
 #include <linux/init.h>
+#include <linux/cpu_pm.h>
 #include <linux/cpuidle.h>
 #include <linux/io.h>
 #include <linux/suspend.h>
@@ -958,6 +959,7 @@ static int exynos4_enter_lowpower(struct cpuidle_device *dev,
 	if (!enter_mode)
 		return exynos4_enter_idle(dev, new_state);
 	else {
+		cpu_pm_enter();
 #ifdef CONFIG_CORESIGHT_ETM
 		etm_disable(0);
 #endif
@@ -968,6 +970,7 @@ static int exynos4_enter_lowpower(struct cpuidle_device *dev,
 #ifdef CONFIG_CORESIGHT_ETM
 		etm_enable(0);
 #endif
+		cpu_pm_exit();
 	}
 
 	return ret;


### PR DESCRIPTION
In low power cpuidle states, the FPU registers get corrupted. By calling
cpu_pm_enter, the VFP module gets notified so that it saves the FPU state and
restores it from RAM the next time a thread uses it.

See http://forum.xda-developers.com/showthread.php?p=57637134 to http://forum.xda-developers.com/showthread.php?p=57643086 (zeitferne is my XDA name, as you can infer from my links to gists there). http://forum.xda-developers.com/galaxy-s2/development-derivatives/kernel-fpbug-stable-4-x-kernel-galaxy-t2978088 might also be interesting.

Obligatory WARNING: Although the patch is reasonably well tested, I just entered this manually in github's online editor. Refer to the linked posts for links to the patchset. However, you have already included all required mainline commits, so I thought this additional three-line change should be doable w/o downloading the full repository.
